### PR TITLE
Add 'font' media type to update-mime-database

### DIFF
--- a/libhildonmime/update-category-database.c
+++ b/libhildonmime/update-category-database.c
@@ -50,6 +50,7 @@ const char *media_types[] = {
 	"multipart",
 	"x-content",
 	"x-epoc",
+	"font",
 };
 
 /* Represents a MIME type */


### PR DESCRIPTION
The 'Warning: Unknown media type in type 'font/ttf''  is no longer reported as the type is now known.

We might need to add more media types later.