### PR TITLE
Fix for compatibility with gtk-doc >= 1.30

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+libhildonmime (4.0.2) unstable; urgency=medium
+  * Fix for compatibility with gtc-doc >= 1.30
+
+ -- Blagovest Petrov <blagovest@petrovs.info> Sun, 20 Nov 2022 21:00:21 +0200
+
 libhildonmime (4.0.1) unstable; urgency=medium
 
   * fix get_service_name_by_mime_type() not able to find non-default application

--- a/docs/libhildonmime-docs.xml
+++ b/docs/libhildonmime-docs.xml
@@ -15,11 +15,28 @@
 
     <chapter id="general">
       <title>General</title>
-      <xi:include href="xml/hildon-mime.xml"/>
-      <xi:include href="xml/hildon-mime-patterns.xml"/>
-      <xi:include href="xml/hildon-uri.xml"/>
+      <xi:include href="xml/hildon-mime.xml">
+        <xi:fallback>
+	  <para>
+	    not available.
+	  </para>
+	</xi:fallback>
+      </xi:include>
+      <xi:include href="xml/hildon-mime-patterns.xml">
+        <xi:fallback>
+	  <para>
+	    not available.
+	  </para>
+	</xi:fallback>
+      </xi:include>
+      <xi:include href="xml/hildon-uri.xml">
+        <xi:fallback>
+	  <para>
+	    not available.
+	  </para>
+	</xi:fallback>
+      </xi:include>
     </chapter>
-
   </part>
 
   <index id="symbols">
@@ -27,6 +44,12 @@
   </index>
   <index role="hierarchy" id="hierarchy">
     <title>Object Hierarchy</title>
-    <xi:include href="xml/tree_index.sgml"/>
+    <xi:include href="xml/tree_index.sgml">
+        <xi:fallback>
+	  <para>
+	    not available.
+	  </para>
+	</xi:fallback>
+      </xi:include>
   </index>
 </book>


### PR DESCRIPTION
gtk-doc syntax is more strict after 1.30 and the build was failing with these errors:

```
../xml/hildon-mime.xml:112: namespace error : Namespace prefix osso on category is not defined
info. Add the tag <osso:category name="name"/> to a mime type to specify that
                                            ^
../xml/hildon-mime.xml:117: namespace error : Namespace prefix osso on category is not defined
    <osso:category name="documents"/>
```

The issue is similar to [this](https://gitlab.gnome.org/GNOME/librsvg/-/issues/457) one from librsvg.