### PR TITLE
hildon-uri: add action objects for xdg-open

### DIFF
--- a/libhildonmime/hildon-uri.h
+++ b/libhildonmime/hildon-uri.h
@@ -63,11 +63,14 @@ typedef struct _HildonURIAction HildonURIAction;
  * types, even if the mime type is unknown.
  * @HILDON_URI_ACTION_FALLBACK: This type of action is used exclusively
  * when the mime type is unknown.
+ * @HILDON_URI_ACTION_XDG: This type of action is used exclusively
+ * when xdg-open should be used instead of a osso service
  **/
 typedef enum {
 	HILDON_URI_ACTION_NORMAL,
 	HILDON_URI_ACTION_NEUTRAL,
 	HILDON_URI_ACTION_FALLBACK,
+	HILDON_URI_ACTION_XDG
 } HildonURIActionType;
 
 typedef enum { 
@@ -109,6 +112,7 @@ HildonURIAction *   hildon_uri_get_default_action            (const gchar       
 							      GError              **error);
 HildonURIAction *   hildon_uri_get_default_action_by_uri     (const gchar          *uri,
 							      GError              **error);
+HildonURIAction *   hildon_uri_get_xdg_action                (void);
 gboolean            hildon_uri_set_default_action            (const gchar          *scheme,
 							      HildonURIAction      *action,
 							      GError              **error);


### PR DESCRIPTION
when using uri_launch applications using libhildonmime can pass a HildonURIAction object to indicate what dbus service they would prefer handle the uri. We recently added the ability for libhildonmime to fallback to xdg-open, but provided no method for an application to specify that it would prefer xdg-open handle the passed uri since xdg-open has no dbus service

this patch addresses this deficiency by adding a new type of HildonURIAction that simply instructs libhildonmime to try xdg-open first